### PR TITLE
fix: [EV-7593] убран дефолтный border, теперь border добавляется только при наличии конкретного пропса

### DIFF
--- a/src/components/use-border/index.ts
+++ b/src/components/use-border/index.ts
@@ -316,15 +316,28 @@ export const useBorder = (props: UseBorderProps): UseBorderOutput => {
     ? transformBorderColor(props.hover.d?.color)
     : undefined;
 
-  if (
-    typeof m !== "undefined" ||
-    typeof d !== "undefined" ||
-    typeof md !== "undefined" ||
-    typeof mdHover !== "undefined" ||
-    typeof dHover !== "undefined" ||
-    typeof mHover !== "undefined"
-  ) {
+  if (typeof m !== "undefined") {
     classNames += "border ";
+  }
+
+  if (typeof md !== "undefined") {
+    classNames += "md:border ";
+  }
+
+  if (typeof d !== "undefined") {
+    classNames += "lg:border ";
+  }
+
+  if (typeof mHover !== "undefined") {
+    classNames += "hover:border ";
+  }
+
+  if (typeof mdHover !== "undefined") {
+    classNames += "md:hover:border ";
+  }
+
+  if (typeof dHover !== "undefined") {
+    classNames += "lg:hover:border ";
   }
 
   const universalMColorValue =


### PR DESCRIPTION
Ранее border применялся всегда при наличии хотя бы одного из модификаторов (m, md, d и т.д.), что приводило к нежелательной границе на мобилке. Теперь border добавляется строго под конкретный брейкпоинт (например, только md:border при md) — это позволяет избежать лишнего бордера на других разрешениях.